### PR TITLE
Use current PHP binary path when on Windows

### DIFF
--- a/src/Composer/Wrapper.php
+++ b/src/Composer/Wrapper.php
@@ -42,8 +42,10 @@ class Wrapper
 
     protected function getComposerCommand()
     {
-        $command = '/usr/bin/env php '.$this->executable->getRealPath();
-        return $command;
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            return PHP_BINARY . ' ' . $this->executable->getRealPath();
+        }
+        return '/usr/bin/env php '.$this->executable->getRealPath();
     }
     
     protected function getComposerArgs()


### PR DESCRIPTION
`/usr/bin/env` does not work on Windows
