### PR TITLE
Fix path on Windows

### DIFF
--- a/src/PHPUnit/FullStackTestCase.php
+++ b/src/PHPUnit/FullStackTestCase.php
@@ -28,7 +28,7 @@ abstract class FullStackTestCase extends \PHPUnit_Framework_TestCase
     protected static function getTempComposerProjectPath()
     {
         $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "ComposerTests" . DIRECTORY_SEPARATOR  . get_called_class();
-        $path = str_replace('\\', '_', $path);
+        $path = str_replace('\\', '/', $path);
         return new \SplFileInfo($path);
     }
 }

--- a/src/PHPUnit/FullStackTestCase.php
+++ b/src/PHPUnit/FullStackTestCase.php
@@ -27,8 +27,11 @@ abstract class FullStackTestCase extends \PHPUnit_Framework_TestCase
     
     protected static function getTempComposerProjectPath()
     {
-        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "ComposerTests" . DIRECTORY_SEPARATOR  . get_called_class();
-        $path = str_replace('\\', '/', $path);
+        $path = sprintf(
+            "%s/ComposerTests/%s",
+            str_replace('\\', '/', sys_get_temp_dir()),
+            str_replace('\\', '_', get_called_class())
+        );
         return new \SplFileInfo($path);
     }
 }


### PR DESCRIPTION
These two fixes are needed to get the `magento-composer-installer` tests running on Windows. 
