### PR TITLE
Shorter directory on Windows

### DIFF
--- a/src/PHPUnit/FullStackTestCase.php
+++ b/src/PHPUnit/FullStackTestCase.php
@@ -27,6 +27,11 @@ abstract class FullStackTestCase extends \PHPUnit_Framework_TestCase
     
     protected static function getTempComposerProjectPath()
     {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $path = sprintf("C:/ComposerTests/%s", str_replace('\\', '_', get_called_class()));
+            return new \SplFileInfo($path);
+        }
+
         $path = sprintf(
             "%s/ComposerTests/%s",
             str_replace('\\', '/', sys_get_temp_dir()),


### PR DESCRIPTION
Windows temporary directory is very deep and causes some tests to fail

I'm having to hard-code `C:` so these tests won't work on a Machine without a `C:\` but I can't think of a  better way. I think it should be fine.
